### PR TITLE
fix: require.async() & partial support of `import()`

### DIFF
--- a/packages/demo-app/browser_modules/test/suite.js
+++ b/packages/demo-app/browser_modules/test/suite.js
@@ -99,3 +99,12 @@ describe('neglect node.js core modules', function() {
     expect(fontkit.create).to.be.a(Function);
   });
 });
+
+describe('dynamic import', function() {
+  it('should recognize require.async', function(done) {
+    require.async('react', function(exports) {
+      expect(exports.Component).to.be.a(Function);
+      done();
+    });
+  });
+});

--- a/packages/demo-app/components/dynamic_imports.js
+++ b/packages/demo-app/components/dynamic_imports.js
@@ -1,0 +1,5 @@
+'use strict';
+
+require.async('react', function(exports) {
+  console.log(exports);
+});

--- a/packages/porter/src/css_module.js
+++ b/packages/porter/src/css_module.js
@@ -10,15 +10,15 @@ const rAtImport = /(?:^|\n)\s*@import\s+(['"])([^'"]+)\1;/g;
 
 module.exports = class CssModule extends Module {
   matchImport(code) {
-    const deps = [];
+    const imports = [];
     let m;
 
     rAtImport.lastIndex = 0;
     while ((m = rAtImport.exec(code))) {
-      deps.push(m[2]);
+      imports.push(m[2]);
     }
 
-    return deps;
+    this.imports = imports;
   }
 
   /**
@@ -30,10 +30,10 @@ module.exports = class CssModule extends Module {
 
     const { fpath } = this;
     const code = this.code || (await fs.readFile(fpath, 'utf8'));
-    const deps = this.deps || this.matchImport(code);
+    if (!this.imports) this.matchImport(code);
 
     // ordering matters in css modules
-    const result = await Promise.all(deps.map(this.parseDep, this));
+    const result = await Promise.all(this.imports.map(this.parseImport, this));
     this.children = result.filter(mod => mod != null);
     this.status = MODULE_LOADED;
   }

--- a/packages/porter/src/less_module.js
+++ b/packages/porter/src/less_module.js
@@ -17,16 +17,16 @@ function getLessPlugin(packet) {
 module.exports = class LessModule extends CssModule {
   matchImport(code) {
     // leave imports to less compiler
-    return [];
+    this.imports = [];
   }
 
-  // async parseDep(dep) {
-  //   if (dep.startsWith('~')) return await super.parseDep(dep.slice(1));
+  // async parseImport(dep) {
+  //   if (dep.startsWith('~')) return await super.parseImport(dep.slice(1));
 
   //   const mod = await this.parseRelative(dep);
   //   if (mod) return mod;
 
-  //   return await super.parseDep(dep);
+  //   return await super.parseImport(dep);
   // }
 
   async transpile({ code, map }) {

--- a/packages/porter/src/packet.js
+++ b/packages/porter/src/packet.js
@@ -418,19 +418,20 @@ module.exports = class Packet {
 
   /**
    * Parse an entry that has code or deps (or both) specified already.
-   * @param {Object} opts
-   * @param {string} opts.entry
-   * @param {string[]} opts.deps
-   * @param {string} opts.code
+   * @param {Object} options
+   * @param {string} options.entry
+   * @param {string[]} options.imports
+   * @param {string} options.code
    */
-  async parseFakeEntry({ entry, deps, code }) {
+  async parseFakeEntry(options = {}) {
+    const { entry, imports = options.deps, code } = options;
     const { entries, files, paths } = this;
     const { moduleCache } = this.app;
     const fpath = path.join(paths[0], entry);
     delete moduleCache[fpath];
     const mod = Module.create({ file: entry, fpath, packet: this });
 
-    Object.assign(mod, { deps, code, fake: true });
+    Object.assign(mod, { imports, code, fake: true });
     entries[mod.file] = files[mod.file] = mod;
     await mod.parse();
     return mod;

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -42,6 +42,7 @@ function waitFor(mod) {
  */
 const fallback = {
   fs: false,
+  stream: 'readable-stream',
 };
 
 class Porter {

--- a/packages/porter/test/unit/compile_entry.test.js
+++ b/packages/porter/test/unit/compile_entry.test.js
@@ -53,6 +53,23 @@ describe('porter.compileEntry()', function() {
       // fake modules should be removed afterwards
       expect(Object.keys(porter.packet.files)).to.not.contain('fake/entry.js');
     });
+
+    it('can compile component with specified deps and code', async function() {
+      const { code } = await porter.compileEntry({
+        entry: 'fake/entry.js',
+        imports: ['yen', 'jquery'],
+        code: `
+          'use strict'
+          var $ = require('yen')
+          $('body').addClass('hidden')
+        `
+      }, { all: true, writeFile: false, loaderConfig: { preload: undefined } });
+
+      const { name, version, main } = porter.packet.find({ name: 'jquery' });
+      expect(code).to.contain(`${name}/${version}/${main}`);
+      // fake modules should be removed afterwards
+      expect(Object.keys(porter.packet.files)).to.not.contain('fake/entry.js');
+    });
   });
 
   describe('.compileEntry({ entry, code }, { loaderConfig })', function() {

--- a/packages/porter/test/unit/js_module.test.js
+++ b/packages/porter/test/unit/js_module.test.js
@@ -53,7 +53,18 @@ describe('JsModule', function() {
     const pkg = porter.packet.find({ name: 'mobx' });
     const mod = pkg.files['dist/index.js'];
     await mod.obtain();
-    assert.deepEqual(mod.deps, [ './mobx.cjs.development.js' ]);
+    assert.deepEqual(mod.imports, [ './mobx.cjs.development.js' ]);
+  });
+
+  it('should recognize dynamic imports', async function() {
+    const mod = await porter.packet.parseEntry('dynamic_imports.js');
+    assert.ok(mod);
+    // static imports is empty
+    assert.deepEqual(mod.imports, []);
+    assert.deepEqual(mod.dynamicImports, [ 'react' ]);
+    await porter.pack();
+    const react = porter.packet.find({ name: 'react' });
+    assert.deepEqual(Object.keys(mod.lock.react), [ react.version ]);
   });
 });
 

--- a/packages/porter/test/unit/packet.test.js
+++ b/packages/porter/test/unit/packet.test.js
@@ -120,6 +120,11 @@ describe('Packet', function() {
       const iconv = porter.packet.find({ name: 'iconv-lite' });
       expect(Object.keys(iconv.dependencies)).to.not.contain('stream');
     });
+
+    it('should fallback stream to readable-stream', function() {
+      const restructure = porter.packet.find({ name: 'restructure' });
+      assert.deepEqual(restructure.browser, { stream: 'readable-stream' });
+    });
   });
 
   describe('packet.prepare()', function() {


### PR DESCRIPTION
- refactor: replace glue code with options.resolve.fallback
- fixes existing usage like `require.async('some-package', exports => exports.default())`