### PR TITLE
fix: js extensions such as { .jsx, .mjs, .cjs }

### DIFF
--- a/packages/demo-app/components/home.css
+++ b/packages/demo-app/components/home.css
@@ -1,0 +1,3 @@
+* {
+  box-sizing: border-box;
+}

--- a/packages/demo-app/components/home_dep.js
+++ b/packages/demo-app/components/home_dep.js
@@ -1,3 +1,4 @@
 'use strict';
 
+require('./home_dep.css');
 console.log('home_dep');

--- a/packages/demo-complex/app/web/components/button.jsx
+++ b/packages/demo-complex/app/web/components/button.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Button(props) {
+  return (
+    <div className="porter-button">
+      <button>{props.children}</button>
+    </div>
+  );
+}

--- a/packages/demo-complex/app/web/home.jsx
+++ b/packages/demo-complex/app/web/home.jsx
@@ -6,6 +6,7 @@ import { greeting } from './utils';
 
 import 'cropper/dist/cropper.css';
 import './stylesheets/app.less';
+import Button from './components/button';
 
 greeting('Hi there!');
 
@@ -13,6 +14,7 @@ function Home() {
   return (
     <div className="page">
       <h1>It works!</h1>
+      <Button>Submit</Button>
     </div>
   );
 }

--- a/packages/demo-complex/app/web/test/suite.js
+++ b/packages/demo-complex/app/web/test/suite.js
@@ -1,0 +1,13 @@
+import expect from 'expect.js';
+import Button from '../components/button';
+import { lowerCase } from '../utils/string.mjs';
+
+describe('import js extensions', function() {
+  it('import "./button.jsx"', function() {
+    expect(Button).to.be.a(Function);
+  });
+
+  it('import "./string.mjs"', function() {
+    expect(lowerCase).to.be.a(Function);
+  });
+});

--- a/packages/demo-complex/app/web/utils/string.mjs
+++ b/packages/demo-complex/app/web/utils/string.mjs
@@ -1,0 +1,4 @@
+export function lowerCase(text)  {
+  if (typeof text !== 'string') return text;
+  return text.toLowerCase();
+}

--- a/packages/demo-complex/package.json
+++ b/packages/demo-complex/package.json
@@ -15,7 +15,9 @@
     "antd": "^4.17.3",
     "classnames": "^2.3.1",
     "cropper": "^4.1.0",
+    "expect.js": "^0.3.1",
     "less": "^4.1.2",
+    "mocha": "^9.2.2",
     "node-dev": "^3.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
@@ -29,6 +31,7 @@
   "scripts": {
     "build": "rm -rf public && node bin/build.js",
     "dev": "rm -rf public && DEBUG=porter,$DEBUG node-dev app.js",
-    "start": "rm -rf public && DEBUG=porter,$DEBUG porter serve --paths app/web"
+    "start": "rm -rf public && DEBUG=porter,$DEBUG porter serve --paths app/web",
+    "test": "rm -rf public && DEBUG=porter,$DEBUG porter serve --paths app/web --headless"
   }
 }

--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -199,6 +199,7 @@
 
   function suffix(id) {
     if (id.slice(-1) == '/') return id + 'index.js';
+    id = id.replace(/\.(?:js|jsx|ts|tsx|mjs|cjs)$/, '.js');
     return /\.(?:css|js|wasm)$/.test(id) ? id : id + '.js';
   }
 

--- a/packages/porter/src/bundle.js
+++ b/packages/porter/src/bundle.js
@@ -9,7 +9,7 @@ const debug = require('debug')('porter');
 const Module = require('./module');
 
 const extMap = {
-  '.js': [ '.js', '.jsx', '.ts', '.tsx', '.json' ],
+  '.js': [ '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.json' ],
   '.wasm': [ '.wasm' ],
   '.css': [ '.css', '.less' ],
 };
@@ -90,7 +90,7 @@ module.exports = class Bundle {
     this.app = app;
     this.packet = packet;
     this.loaderConfig = loaderConfig;
-    this.#entries = Array.isArray(entries) && entries.length > 0 ? entries : null;
+    this.#entries = entries && entries.length > 0 ? [].concat(entries) : null;
     this.#loaderCache = {};
 
     let scope = 'packet';

--- a/packages/porter/src/module.js
+++ b/packages/porter/src/module.js
@@ -207,22 +207,13 @@ module.exports = class Module {
    * @param {string} opts.code
    * @returns {Array}
    */
-  async checkImports({ code, intermediate = false }) {
-    const { imports, dynamicImports = [] } = this;
+  async checkImports({ code }) {
+    const { imports } = this;
     this.matchImport(code);
-
-    for (const dep of this.imports) {
-      if (!imports.includes(dep)) await this.parseImport(dep);
-    }
-
-    // when checking imports introduced by intermediate code, dynamic imports need reset
-    // import(specifier) -> Promise.resolve(require(specifier))
-    if (intermediate) {
-      for (let i = this.imports.length; i >= 0; i--) {
-        const specifier = this.imports[i];
-        if (dynamicImports.includes(specifier)) this.imports.splice(i, 1);
+    if (this.imports) {
+      for (const dep of this.imports) {
+        if (!imports.includes(dep)) await this.parseImport(dep);
       }
-      this.dynamicImports = dynamicImports;
     }
   }
 

--- a/packages/porter/src/packet.js
+++ b/packages/porter/src/packet.js
@@ -38,6 +38,8 @@ Module.create = function(opts) {
       return new TsModule(opts);
     case '.js':
     case '.jsx':
+    case '.mjs':
+    case '.cjs':
       return new JsModule(opts);
     case '.less':
       return new LessModule(opts);

--- a/packages/porter/test/unit/bundle.test.js
+++ b/packages/porter/test/unit/bundle.test.js
@@ -4,6 +4,7 @@ const { strict: assert } = require('assert');
 const fs = require('fs/promises');
 const path = require('path');
 const Porter = require('../..');
+const Bundle = require('../../src/bundle');
 
 describe('Bundle without preload', function() {
   const root = path.resolve(__dirname, '../../../demo-app');
@@ -24,9 +25,22 @@ describe('Bundle without preload', function() {
     await porter.destroy();
   });
 
+  describe('constructor()', async function() {
+    it('should not tamper with passed entries', async function() {
+      const { packet } = porter;
+      await packet.parseEntry('home.js');
+      Bundle.wrap({ packet, entries: [ 'home.js' ]});
+      await packet.parseEntry('home.css');
+      Bundle.wrap({ packet, entries: [ 'home.css' ]});
+      // bundle of home.js should not include home.css
+      assert.deepEqual(packet.bundles['home.js'].entries, [ 'home.js' ]);
+    });
+  });
+
   describe('[Symbol.iterator]', function() {
     it('should iterate over all modules that belong to bundle', async function() {
       assert.deepEqual(Object.keys(porter.packet.bundles).sort(), [
+        'home.css',
         'home.js',
         'lazyload.js',
         'lazyload_dep.js',
@@ -283,6 +297,7 @@ describe('Bundle with CSS in JS', function() {
         'app/web/home_dep.js',
         'app/web/i18n/index.js',
         'app/web/utils/index.js',
+        'app/web/components/button.jsx',
         'app/web/home.jsx',
       ]);
     });

--- a/packages/porter/test/unit/js_module.test.js
+++ b/packages/porter/test/unit/js_module.test.js
@@ -99,6 +99,7 @@ describe('JsModule import CSS', function() {
       'app/web/utils/index.js',
       'node_modules/cropper/dist/cropper.css',
       'app/web/stylesheets/app.less',
+      'app/web/components/button.jsx',
     ]);
   });
 });

--- a/packages/porter/test/unit/less_module.test.js
+++ b/packages/porter/test/unit/less_module.test.js
@@ -41,6 +41,7 @@ describe('test/unit/less_module.test.js', function() {
       'app/web/utils/index.js',
       'node_modules/cropper/dist/cropper.css',
       'app/web/stylesheets/app.less',
+      'app/web/components/button.jsx',
     ]);
   });
 

--- a/packages/porter/test/unit/packet.test.js
+++ b/packages/porter/test/unit/packet.test.js
@@ -92,7 +92,8 @@ describe('Packet', function() {
 
     it('recognize css @import', function() {
       const cssFiles = Object.keys(porter.packet.files).filter(file => file.endsWith('.css'));
-      expect(cssFiles).to.eql([
+      expect(cssFiles.sort()).to.eql([
+        'home_dep.css',
         'stylesheets/app.css',
         'stylesheets/common/base.css',
         'stylesheets/common/reset.css'

--- a/packages/porter/test/unit/wasm_module.test.js
+++ b/packages/porter/test/unit/wasm_module.test.js
@@ -29,4 +29,12 @@ describe('WasmModule', function() {
     const mod = await packet.parseFile('pkg/bundler/index_bg.wasm');
     assert.equal(mod.status, MODULE_LOADED);
   });
+
+  it('should reload without error', async function() {
+    const packet = porter.packet.find({ name: '@cara/hello-wasm' });
+    const mod = await packet.parseFile('pkg/bundler/index_bg.wasm');
+    await assert.doesNotReject(async function() {
+      await mod.reload();
+    });
+  });
 });


### PR DESCRIPTION
```js
import './foo.mjs';
import './foo.cjs';
import './bar'; // -> bar.jsx
import './baz'; // -> baz.tsx
// etc.
```

according to the standard, specifiers of es modules should include the file extension, hance the `.mjs` auto resolution is not added. also fixed a minor issue the when both js and css entries use the same filename, such as app.js and app.css, the js bundle might get wrong module resolution data.