### PR TITLE
fix: Response can only be consumed once in some lower version browsers

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -111,7 +111,7 @@
 
   function loadWasm(module, imports) {
     if (typeof WebAssembly.instantiateStreaming === 'function') {
-      return WebAssembly.instantiateStreaming(module, imports).catch(function onError(err) {
+      return WebAssembly.instantiateStreaming(module.clone(), imports).catch(function onError(err) {
         if (module.headers.get('Content-Type') != 'application/wasm') {
           console.warn('`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n', err);
         } else {


### PR DESCRIPTION
chrome 70 版本 import wasm 包时报错：TypeError: Failed to execute 'arrayBuffer' on 'Response': body stream is locked

According to MDN: https://developer.mozilla.org/en-US/docs/Web/API/Response/clone

> clone() throws a [TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError) if the response body has already been used. In fact, the main reason clone() exists is to allow multiple uses of body objects (when they are one-use only.)

Related Q&A on stackoverflow.com:
https://stackoverflow.com/questions/53511974/javascript-fetch-failed-to-execute-json-on-response-body-stream-is-locked