### PR TITLE
fix: always try to reload bundle in case new module were added

### DIFF
--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -360,8 +360,9 @@ class Porter {
     let mod = packet.files[file];
     let bundle = packet.bundles[mod ? mod.file : file];
 
-    // in case root entry is not parsed yet
-    if (packet === this.packet && !bundle) {
+    // - bundle is accessed for the first time and the entry is not prepared in advance
+    // - bundle is a css bundle generated from js entry
+    if (packet === this.packet && (!bundle || !mod)) {
       debug('parseEntry', file);
       mod = await packet.parseEntry(file.replace(rExt, '')).catch(() => null);
       if (ext === '.css') mod = await packet.parseEntry(file).catch(() => mod);
@@ -369,7 +370,7 @@ class Porter {
       [ bundle ] = mod ? Bundle.wrap({ packet, entries: [ mod.file ], format: ext }) : [];
     }
 
-    // prefer the real file extension
+    this.parseCache[id] = null;
     return bundle;
   }
 


### PR DESCRIPTION
before this change, there was this bug:

1. given dependency graph like home.js -> foo.css
2. two bundles will be created, one for home.js, one for the css extracted from home.js, namely, home.css
3. when user creates the actual home.css source file, the bundle of home.css didn't update