### PR TITLE
fix: no need to set source root when options.source.inline is positive

### DIFF
--- a/packages/porter/src/bundle.js
+++ b/packages/porter/src/bundle.js
@@ -419,7 +419,7 @@ module.exports = class Bundle {
       node.add(`porter["import"](${JSON.stringify(mod.id)})`);
     }
 
-    const result = node.join('\n').toStringWithSourceMap({ sourceRoot: app.source.root });
+    const result = node.join('\n').toStringWithSourceMap();
     this.#code = result.code;
     this.#map = result.map;
     this.#cacheKey = cacheKey;

--- a/packages/porter/test/unit/compile_all.test.js
+++ b/packages/porter/test/unit/compile_all.test.js
@@ -191,7 +191,8 @@ describe('Porter with preload', function() {
     it('should set sourcesContent in components source map', async function() {
       const fpath = path.join(porter.output.path, `${manifest['home.js']}.map`);
       const map = JSON.parse(await readFile(fpath, 'utf8'));
-      assert.equal(map.sourceRoot, porter.source.root);
+      // no need to set source root since sources content are inlined already
+      // assert.equal(map.sourceRoot, porter.source.root);
       assert.equal(map.sourcesContent.filter(item => item).length, map.sources.length);
     });
 
@@ -199,7 +200,7 @@ describe('Porter with preload', function() {
       const react = porter.packet.find({ name: 'react' });
       const fpath = path.join(porter.output.path, `${react.bundle.outputPath}.map`);
       const map = JSON.parse(await readFile(fpath, 'utf8'));
-      assert.equal(map.sourceRoot, porter.source.root);
+      // assert.equal(map.sourceRoot, porter.source.root);
       assert.equal(map.sourcesContent.filter(item => item).length, map.sources.length);
     });
   });


### PR DESCRIPTION
if source root were set to '/' and sources were something like `porter:///foo.js`, safari will turn the source into `/porter:///foo.js` which then generates too much level of directories in safari developer tools' sources tab