### PR TITLE
fix: replace arrow function in loader.js with regular one

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -175,7 +175,9 @@
         // ignite the wasm module to execute context module for the second time
         callback();
       })
-      .catch(err => callback(err));
+      .catch(function onError(err) {
+        callback(err);
+      });
   }
 
   function request(uri, callback) {


### PR DESCRIPTION
loader.js isn't processed with babel or any other transpilers yet