### PR TITLE
fix: porter.lock should be updated incrementally

### DIFF
--- a/packages/demo-app/browser_modules/loader/suite.js
+++ b/packages/demo-app/browser_modules/loader/suite.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const expect = require('expect.js');
+const { porter } = window;
+
+describe('loader', function() {
+  it('porter.merge(target, source)', function() {
+    expect(porter.merge(null, {})).to.eql(null);
+    expect(porter.merge({}, null)).to.eql({});
+    expect(porter.merge({ a: 1 }, { a: 2 })).to.eql({ a: 2 });
+    expect(porter.merge({ a: 1 }, { a: 2, b: 3 })).to.eql({ a: 2, b: 3 });
+    expect(porter.merge({ a: 1 }, { a: { b: 2 } })).to.eql({ a: { b: 2 } });
+    expect(porter.merge({ a: { b: 2 } }, { a: { c: 3 } })).to.eql({ a: { b: 2, c: 3 } });
+    expect(porter.merge({
+      a: { '1.0.0': { b: 1 } },
+    }, {
+      a: { '1.0.0': { c: 2 } },
+    })).to.eql({
+      a: { '1.0.0': { b: 1, c: 2 } },
+    });
+  });
+});

--- a/packages/demo-app/browser_modules/test/suite.js
+++ b/packages/demo-app/browser_modules/test/suite.js
@@ -10,6 +10,7 @@ require('../mad-import/suite');
 require('../require-json/suite');
 require('../brfs/suite');
 require('../dynamic-import/suite');
+require('../loader/suite');
 
 describe('global', function() {
   it('should equal to window', function() {

--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -614,7 +614,21 @@
       rootImport(specifiers, function() {
         if (fn) fn.apply(null, arrayFn.slice.call(arguments, preload.length));
       });
-    }
+    },
+    merge: function Porter_merge(target, source) {
+      if (source == null || target == null) return target;
+      if (typeof source !== 'object' || typeof target !== 'object') return target;
+      for (const key in source) {
+        if (!source.hasOwnProperty(key)) continue;
+        var value = source[key];
+        if (value == null || typeof value !== 'object' || target[key] == null || typeof target[key] !== 'object') {
+          target[key] = value;
+        } else {
+          Porter_merge(target[key], value);
+        }
+      }
+      return target;
+    },
   });
 
   global.define = preload.length > 0 ? cacheDefine : define;

--- a/packages/porter/src/bundle.js
+++ b/packages/porter/src/bundle.js
@@ -409,7 +409,7 @@ module.exports = class Bundle {
 
     if (mod.isRootEntry && !mod.isPreload && format === '.js') {
       await Promise.all(children.map(child => child.obtain({ minify })));
-      node.prepend(`Object.assign(porter.lock, ${JSON.stringify(mod.lock)})`);
+      node.prepend(`porter.merge(porter.lock, ${JSON.stringify(mod.lock)})`);
     }
 
     if (mod.isRootEntry && loader !== false && format === '.js') {
@@ -454,7 +454,7 @@ module.exports = class Bundle {
 
     if (mod.isRootEntry && !mod.isPreload && format === '.js') {
       await Promise.all(children.map(child => child.fuzzyObtain({ minify })));
-      chunks.unshift(`Object.assign(porter.lock, ${JSON.stringify(mod.lock)})`);
+      chunks.unshift(`porter.merge(porter.lock, ${JSON.stringify(mod.lock)})`);
     }
 
     if (mod.isRootEntry && loader !== false && format === '.js') {


### PR DESCRIPTION
take following three entries for example

- entry/a.js -> import('./b.js') or import('./c.js') 
- entry/b.js -> overrides porter.lock because itself is a root entry and might have its own dependencies that needs to be mapped
- entry/c.js ->  overrides porter.lock because itself is a root entry and might have its own dependencies that needs to be mapped

when entry/a.js -> import('./b.js') happen, the manifest `porter.lock[pkg.name][pkg.version].manifest` will be overridden by the `Object.assign(porter.lock, {...})` in entry/b.js

This pr changes this behavior to a customized `porter.merge(target, source)`, which merges objects at arbitrary depth. 