### PR TITLE
fix: module ids with jsx|tsx extensions should always be converted to js

### DIFF
--- a/packages/porter/src/module.js
+++ b/packages/porter/src/module.js
@@ -25,7 +25,7 @@ module.exports = class Module {
   }
 
   get id() {
-    const file = this.file.replace(/\.tsx?/, '.js');
+    const file = this.file.replace(/\.[jt]sx?/, '.js');
     if (!this.packet.parent) return file;
     return [this.name, this.version, file].join('/');
   }

--- a/packages/porter/test/complex/index.test.js
+++ b/packages/porter/test/complex/index.test.js
@@ -40,6 +40,13 @@ describe('test/complex/index.test.js', function() {
     });
   });
 
+  describe('module.id', function() {
+    it('should convert extension to .js', async function() {
+      const mod = porter.packet.files['about.jsx'];
+      assert.equal(mod.id, 'about.js');
+    });
+  });
+
   describe('module.children', function() {
     it('should have css dependencies parsed', async function() {
       const mod = porter.packet.files['home.jsx'];


### PR DESCRIPTION
att