### PR TITLE
fix: compile either css entries orders shall yield with same result

### DIFF
--- a/packages/porter/src/bundle.js
+++ b/packages/porter/src/bundle.js
@@ -30,19 +30,25 @@ module.exports = class Bundle {
     const { packet, entries } = options;
     // the default bundle
     const bundle = Bundle.create(options);
-    const results = [ bundle ];
+    const results = [bundle];
     const entry = packet.files[entries[0]];
 
     if (!entry) return results;
     if (bundle.format === '.css') {
       for (const mod of Object.values(packet.entries)) {
-        if (mod.file !== entry.file && mod.file.replace(rExt, '.css') === entry.file) {
+        if (!entries.includes(mod.file) && mod.file.replace(rExt, '.css') === entry.file) {
           entries.push(mod.file);
           break;
         }
       }
+      // if there are multiple entries, the returned bundle might not contain all of them
       for (const file of entries) {
-        if (!bundle.entries.includes(file)) bundle.entries.push(file);
+        if (bundle.entries.includes(file)) continue;
+        if (path.extname(file) === '.css') {
+          bundle.entries.push(file);
+        } else {
+          bundle.entries.unshift(file);
+        }
       }
       return results;
     }

--- a/packages/porter/test/integration/porter.test.js
+++ b/packages/porter/test/integration/porter.test.js
@@ -164,7 +164,7 @@ describe('Porter', function() {
 
       await fs.writeFile(fpath, 'body { color: navy }');
       const res2 = await requestPath('/about.css');
-      assert.deepEqual(bundle.entries.sort(), [ 'about.css', 'about.js' ]);
+      assert.deepEqual(bundle.entries, [ 'about.js', 'about.css' ]);
       assert.notEqual(res.text, res2.text);
     });
   });


### PR DESCRIPTION
not matter the entries are `['home.js', 'home.css']` or `['home.css', 'home.js']`