### PR TITLE
feat: transpile typescript code with babel

### DIFF
--- a/packages/demo-typescript/.babelrc
+++ b/packages/demo-typescript/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [
     "@babel/preset-env",
+    "@babel/preset-typescript",
     "@babel/preset-react"
   ]
 }

--- a/packages/demo-typescript/components/about.tsx
+++ b/packages/demo-typescript/components/about.tsx
@@ -1,0 +1,16 @@
+import React, { useRef, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import heredoc from 'heredoc';
+
+function App() {
+  const container = useRef<HTMLElement>();
+  useEffect(function() {
+    if (container.current == null) return;
+    container.current.innerHTML = heredoc(function() {/*
+      <h1>It works!</h1>
+    */});
+  }, [container.current]);
+  return <div ref={container} />;
+}
+
+ReactDOM.render(<App />, document.querySelector('#ReactApp'));

--- a/packages/demo-typescript/package.json
+++ b/packages/demo-typescript/package.json
@@ -11,6 +11,8 @@
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
+    "@babel/preset-typescript": "^7.18.6",
+    "@cara/porter": "^4.3.4",
     "@cara/porter-cli": "^4.3.4",
     "@types/expect.js": "^0.3.29",
     "@types/mocha": "^9.0.0",
@@ -21,6 +23,7 @@
     "eslint-plugin-jsx": "^0.1.0",
     "eslint-plugin-typescript": "^0.14.0",
     "expect.js": "^0.3.1",
+    "heredoc": "^1.3.1",
     "mocha": "^9.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -28,6 +31,8 @@
   },
   "scripts": {
     "start": "rm -rf public && DEBUG=porter,$DEBUG porter serve",
-    "test": "rm -rf public && DEBUG=porter,$DEBUG porter serve --headless"
+    "test:web": "rm -rf public && DEBUG=porter,$DEBUG porter serve --headless",
+    "test:node": "DEBUG=porter mocha --recursive --exit --timeout 30000",
+    "test": "npm run test:node && npm run test:web"
   }
 }

--- a/packages/demo-typescript/test/.eslintrc
+++ b/packages/demo-typescript/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "parserOptions": {
+    "sourceType": "script"
+  }
+}

--- a/packages/demo-typescript/test/babel.test.js
+++ b/packages/demo-typescript/test/babel.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const path = require('path');
+const { strict: assert } = require('assert');
+const Porter = require('@cara/porter');
+
+describe('packages/demo-typescript/test/babel.test.js', function() {
+  const root = path.resolve(__dirname, '..');
+  let porter;
+  let packetFn;
+  let tryRequire;
+
+  before(async function() {
+    porter = new Porter({
+      root,
+      entries: ['app.tsx', 'about.tsx'],
+      cache: { clean: true },
+      transpile: { typescript: 'babel' },
+    });
+    packetFn = porter.packet.constructor.prototype;
+    tryRequire = packetFn.tryRequire;
+    packetFn.tryRequire = function stubTryRequire(specifier) {
+      if (specifier === 'typescript') return null;
+      return tryRequire.call(this, specifier);
+    };
+    await porter.ready();
+  });
+
+  after(async function() {
+    packetFn.tryRequire = tryRequire;
+    await porter.destroy();
+  });
+
+  describe('porter.typescript', function() {
+    it('should disable tsc', function() {
+      assert.notEqual(porter.transpile.typescript, 'tsc');
+    });
+  });
+
+  describe('module.load()', function() {
+    it('need to neglect type imports in advance', async function() {
+      const mod = porter.packet.files['app.tsx'];
+      assert.deepEqual(mod.dynamicImports, ['./utils/math']);
+      assert.deepEqual(mod.imports, ['react', 'react-dom', 'prismjs', './home']);
+    });
+  });
+
+  describe('module.transpile()', function() {
+    it('should neglect dependencies excluded by babel plugin', async function() {
+      const mod = porter.packet.files['about.tsx'];
+      assert.deepEqual(mod.imports, ['react', 'react-dom']);
+    });
+  });
+});

--- a/packages/porter/src/porter.js
+++ b/packages/porter/src/porter.js
@@ -58,7 +58,7 @@ class Porter {
     const output = { path: 'public', ...opts.output };
     output.path = path.resolve(root, output.path);
 
-    const transpile = { include: [], ...opts.transpile };
+    const transpile = { include: [], typescript: 'tsc', ...opts.transpile };
     const cachePath = path.resolve(root, opts.cache && opts.cache.path || output.path);
     const cache = new Cache({ ...opts.cache, path: cachePath });
 
@@ -125,7 +125,7 @@ class Porter {
 
   async readFilePath(fpath) {
     if (!fpath) return null;
-    try { 
+    try {
       return await Promise.all([
         readFile(fpath),
         lstat(fpath).then(stats => ({ 'Last-Modified': stats.mtime.toJSON() }))
@@ -426,6 +426,7 @@ class Porter {
     }
 
     const mod = await packet.parseFile(file);
+    if (!mod) return;
     const { code } = await mod.obtain();
     const mtime = (await lstat(mod.fpath)).mtime.toJSON();
     return [code, { 'Last-Modified': mtime }];

--- a/packages/porter/test/typescript/index.test.js
+++ b/packages/porter/test/typescript/index.test.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const { strict: assert } = require('assert');
-const fs = require('fs/promises');
 const Porter = require('../..');
 
 describe('test/typescript/index.test.js', function() {
@@ -10,10 +9,10 @@ describe('test/typescript/index.test.js', function() {
   let porter;
 
   before(async function() {
-    await fs.rm(path.join(root, 'public'), { recursive: true, force: true });
     porter = new Porter({
       root,
       entries: [ 'app.tsx' ],
+      cache: { clean: true },
     });
     await porter.ready();
   });


### PR DESCRIPTION
```js
new Porter({
  typescript: { compiler: 'babel' },  // default is 'tsc'
});
```
then typescript modules will be compiled with the babel config found at project root instead. 