### PR TITLE
fix: worker entries in root packet should present in module manifest

### DIFF
--- a/examples/app/browser_modules/test/suite.js
+++ b/examples/app/browser_modules/test/suite.js
@@ -94,6 +94,26 @@ describe('missing dep', function() {
   });
 });
 
+describe('worker in app', function() {
+  it('should recognize worker-loader', function(done) {
+    const Worker = require('worker-loader!./worker.js');
+    const worker = new Worker();
+    worker.addEventListener('message', function(e) {
+      expect(e.data).to.eql('hello from worker');
+      done();
+    });
+  });
+
+  it('should recognize ?worker', function(done) {
+    const Worker = require('./worker.js?worker');
+    const worker = new Worker();
+    worker.addEventListener('message', function(e) {
+      expect(e.data).to.eql('hello from worker');
+      done();
+    });
+  });
+});
+
 describe('worker from dependency', function() {
   it('should be able to load dependencies that have web workers', async function() {
     const greeting = require('@cara/demo-worker/');

--- a/examples/app/browser_modules/test/worker.js
+++ b/examples/app/browser_modules/test/worker.js
@@ -1,0 +1,3 @@
+'use strict';
+
+postMessage('hello from worker');

--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -398,7 +398,7 @@
     }
   };
 
-  var rWorkerLoader = /^worker-loader[?!]/;
+  var rWorkerLoader = /(?:^worker-loader[?!]|[?&]worker\b)/;
 
   Module.prototype.resolve = function() {
     var mod = this;
@@ -455,7 +455,7 @@
 
     function require(specifier) {
       if (rWorkerLoader.test(specifier)) {
-        return workerFactory(context)(specifier.split('!').pop());
+        return workerFactory(context)(specifier.split('!').pop().split('?').shift());
       }
       var id = Module.resolve(specifier, mod.id);
       // module might be turned off on purpose with `{ foo: false }` in browser field.

--- a/packages/porter/src/bundle.js
+++ b/packages/porter/src/bundle.js
@@ -73,6 +73,18 @@ module.exports = class Bundle {
       results.unshift(cssBundle);
     }
 
+    // import 'worker-loader!./foo.worker.js';
+    // import './bar.worker.js?worker';
+    if (!packet.parent) {
+      for (const mod of entry.immediateFamily) {
+        if (mod !== entry && mod.packet === packet && mod.isWorker) {
+          const depBundle = Bundle.create({ packet, entries: [mod.file] });
+          if (!depBundle.parent) depBundle.parent = bundle;
+          bundle.children.push(depBundle);
+        }
+      }
+    }
+
     for (const mod of entry.dynamicFamily) {
       // import(specifier);
       const depBundles = Bundle.wrap({

--- a/packages/porter/src/module.js
+++ b/packages/porter/src/module.js
@@ -204,6 +204,15 @@ module.exports = class Module {
         for (const key of searchParams.keys()) result[key] = searchParams.get(key);
         loaders[loader] = result;
       }
+    } else if (dep.includes('?')) {
+      const [pathname, search] = dep.split('?');
+      dep = pathname;
+      const searchParams = new URLSearchParams(search);
+      if (searchParams.has('worker')) {
+        const result = {};
+        for (const key of searchParams.keys()) result[key] = searchParams.get(key);
+        loaders['worker-loader'] = result;
+      }
     }
 
     const { packet, app } = this;

--- a/packages/porter/test/unit/bundle.test.js
+++ b/packages/porter/test/unit/bundle.test.js
@@ -56,6 +56,7 @@ describe('Bundle without preload', function() {
       });
       assert.deepEqual(files, [
         'browser_modules/test/suite.js',
+        'browser_modules/test/worker.js',
         'browser_modules/mad-import/foo.js',
         'browser_modules/require-json/测试数据 4.json',
         '../../node_modules/chart.js/dist/Chart.js',
@@ -78,6 +79,28 @@ describe('Bundle without preload', function() {
       assert.equal(packet.bundles['dynamic-import/foo.js'].format, '.js');
       assert.equal(packet.bundles['dynamic-import/foo.css'].format, '.css');
     });
+
+    it('should create bundles for workers', async function() {
+      const { packet } = porter;
+      const bundle = packet.bundles['test/worker.js'];
+      assert.ok(bundle);
+      assert.equal(bundle.format, '.js');
+      assert.equal(bundle.parent, packet.bundles['test/suite.js']);
+      const entry = packet.files['test/suite.js'];
+      assert.deepEqual(Object.keys(entry.lock[packet.name][packet.version].manifest), [
+        'lazyload_dep.js',
+        'lazyload.js',
+        'test/suite.css',
+        'test/worker.js',
+        'mad-import/foo.js',
+        'require-json/测试数据 4.json',
+        'dynamic-import/sum.js',
+        'dynamic-import/foo.css',
+        'dynamic-import/foo.js',
+        'dynamic-import/bar.css',
+        'dynamic-import/bar.js',
+      ]);
+    });
   });
 
   describe('[Symbol.iterator]', function() {
@@ -97,6 +120,7 @@ describe('Bundle without preload', function() {
         'stylesheets/app.css',
         'test/suite.css',
         'test/suite.js',
+        'test/worker.js',
       ]);
       const bundle = porter.packet.bundles['home.js'];
       const modules = Array.from(bundle);

--- a/packages/porter/test/unit/match_require.test.js
+++ b/packages/porter/test/unit/match_require.test.js
@@ -213,6 +213,13 @@ describe('matchRequire.findAll()', function() {
     expect(imports).to.contain('worker-loader!./parserWorker.js');
   });
 
+  it('should match ./parserWorker.js?worker', async function() {
+    const { imports } = matchRequire.findAll(`
+      import worker from './parserWorker.js?worker&inline';
+    `);
+    assert.deepEqual(imports, ['./parserWorker.js?worker&inline']);
+  });
+
   it('should match require.async()', async function() {
     const { imports, dynamicImports } = matchRequire.findAll(`
       require('foo');


### PR DESCRIPTION
also support worker syntax of vite:

```js
import Worker from './worker.js?worker';
```