### PR TITLE
fix: handle package alias properly

### DIFF
--- a/examples/app/browser_modules/test/suite.js
+++ b/examples/app/browser_modules/test/suite.js
@@ -144,3 +144,16 @@ describe('css entries', function() {
     assert.equal(links.filter(link => link.href.includes('test/suite')).length, 1);
   });
 });
+
+describe('package alias', function() {
+  it('should not be mixed with original package', function() {
+    assert.equal(typeof require('jquery'), 'function');
+    assert.equal(require('jquery/package.json').version.split('.').shift(), '3');
+  });
+
+  it('should be able to require package alias', function() {
+    assert.equal(typeof require('jquery2'), 'function');
+    assert.equal(require('jquery2/package.json').name, 'jquery');
+    assert.equal(require('jquery2/package.json').version.split('.').shift(), '2');
+  });
+});

--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -40,6 +40,7 @@
     "iconv-lite": "^0.4.24",
     "inferno": "^3.9.0",
     "jquery": "^3.3.1",
+    "jquery2": "npm:jquery@^2.2.4",
     "jsencrypt": "^3.3.1",
     "mobx": "^6.3.13",
     "mocha": "^9.1.1",

--- a/examples/app/test/index.test.js
+++ b/examples/app/test/index.test.js
@@ -42,6 +42,14 @@ describe('test/app/index.test.js', function() {
     });
   });
 
+  describe('packet.parsePacket', function() {
+    it('should replace package name with alias if present', async function() {
+      const packet = porter.packet.find({ name: 'jquery2' });
+      assert.ok(packet);
+      assert.equal(packet.name, 'jquery2');
+    });
+  });
+
   describe('bundle[Symbol.iterator]', function() {
     it('should include itself when bundling isolated packet', async function() {
       const packet = porter.packet.find({ name: 'react' });

--- a/examples/typescript/test/tsc.test.js
+++ b/examples/typescript/test/tsc.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const { strict: assert } = require('assert');
 const Porter = require('@cara/porter');
 
-describe('test/typescript/index.test.js', function() {
+describe('examples/typescript/test/tsc.test.js', function() {
   const root = path.resolve(__dirname, '..');
   let porter;
 

--- a/packages/porter/src/packet.js
+++ b/packages/porter/src/packet.js
@@ -110,7 +110,7 @@ module.exports = class Packet {
     if (this.name == 'brotli') this.browser.fs = false;
   }
 
-  static async create({ dir, parent, app }) {
+  static async create({ name, dir, parent, app }) {
     // cnpm (npminstall) dedupes dependencies with symbolic links
     dir = await fs.realpath(dir);
     const content = await fs.readFile(path.join(dir, 'package.json'), 'utf8');
@@ -118,12 +118,12 @@ module.exports = class Packet {
 
     // prefer existing packet to de-duplicate packets
     if (app.packet) {
-      const { name, version } = data;
+      const { version } = data;
       const packet = app.packet.find({ name, version });
       if (packet) return packet;
     }
 
-    const packet = new Packet({ dir, parent, app, packet: data });
+    const packet = new Packet({ dir, parent, app, packet: { ...data, name } });
     await packet.prepare();
     return packet;
   }
@@ -477,7 +477,7 @@ module.exports = class Packet {
 
       if (existsSync(dir)) {
         const { app } = this;
-        const packet = await Packet.create({ dir, parent: this, app });
+        const packet = await Packet.create({ name, dir, parent: this, app });
         this.dependencies[packet.name] = packet;
         return await packet.parseEntry(entry);
       }


### PR DESCRIPTION
```js
    "jquery": "^3.3.1",
    "jquery2": "npm:jquery@^2.2.4",
```

- https://docs.npmjs.com/cli/v9/commands/npm-install