### PR TITLE
chore: deprecate window.define(id, deps, factory)

### DIFF
--- a/packages/porter/loader.js
+++ b/packages/porter/loader.js
@@ -344,7 +344,8 @@
       define.apply(null, predefineModules[i]);
     }
     predefineModules = [];
-    global.define = define;
+    system.define = define;
+    if (global.define === cacheDefine) global.define = define;
     for (var name in system.entries) {
       var mod = registry[name];
       mod.status = MODULE_FETCHED;
@@ -660,9 +661,15 @@
       }
       return target;
     },
+    define: preload.length > 0 ? cacheDefine : define,
   });
 
-  global.define = preload.length > 0 ? cacheDefine : define;
+  /**
+   * @deprecated
+   * future modules should not rely on global define because it might interfere with other module systems
+   */
+  if (!global.define) global.define = system.define;
+
   global.porter = system;
 
   global.process = {

--- a/packages/porter/src/js_module.js
+++ b/packages/porter/src/js_module.js
@@ -136,7 +136,7 @@ module.exports = class JsModule extends Module {
     const { id, imports } = this;
     return {
       code: [
-        `define(${JSON.stringify(id)}, ${JSON.stringify(imports)}, function(require, exports, module, __module) {${code}`,
+        `porter.define(${JSON.stringify(id)}, ${JSON.stringify(imports)}, function(require, exports, module, __module) {${code}`,
         '})'
       ].join('\n'),
       map

--- a/packages/porter/src/json_module.js
+++ b/packages/porter/src/json_module.js
@@ -31,7 +31,7 @@ module.exports = class JsonModule extends Module {
     const { code } = await this.load();
 
     return {
-      code: `define(${JSON.stringify(id)}, ${code.trim()})`,
+      code: `porter.define(${JSON.stringify(id)}, ${code.trim()})`,
     };
   }
 

--- a/packages/porter/test/unit/compile_all.test.js
+++ b/packages/porter/test/unit/compile_all.test.js
@@ -62,7 +62,7 @@ describe('Porter with preload', function() {
     it('should compile entries with same-packet dependencies bundled', async function () {
       const fpath = path.join(porter.output.path, manifest['home.js']);
       const content = await readFile(fpath, 'utf8');
-      assert(content.includes('define("home_dep.js",'));
+      assert(content.includes('porter.define("home_dep.js",'));
       assert(content.includes('porter.lock'));
     });
 
@@ -127,7 +127,7 @@ describe('Porter with preload', function() {
       const react = porter.packet.find({ name: 'react' });
       const fpath = path.join(porter.output.path, react.bundle.outputPath);
       const content = await fs.readFile(fpath, 'utf-8');
-      assert.ok(content.split('\n').every(line => /^(?:define\(|\/\/#)/.test(line)));
+      assert.ok(content.split('\n').every(line => /^(?:porter.define\(|\/\/#)/.test(line)));
     });
 
     it('should compile stylesheets', async function() {


### PR DESCRIPTION
module systems at the AMD era commonly use `window.define()` to transport cjs modules into browser ready, such as https://github.com/modulex/modulex , https://github.com/seajs/seajs , or https://github.com/kissyteam/kissy

it is unnecessary to following this convention nowadays, it is intended that the pack result should be more enclosed. 